### PR TITLE
Ensure presence of color column in annotations

### DIFF
--- a/insitupy/_constants.py
+++ b/insitupy/_constants.py
@@ -71,6 +71,9 @@ FLUO_CMAP = [
     "white"       # for overlays or reference
 ]
 
+## colors
+RED = (255, 0, 0)
+
 
 # font size
 def _init_mpl_fontsize(scale_factor=1):

--- a/insitupy/dataclasses/dataclasses.py
+++ b/insitupy/dataclasses/dataclasses.py
@@ -16,7 +16,7 @@ from parse import *
 from shapely import MultiPoint, MultiPolygon, Point, Polygon, affinity
 
 from insitupy import WITH_NAPARI, __version__
-from insitupy._constants import FORBIDDEN_ANNOTATION_NAMES
+from insitupy._constants import FORBIDDEN_ANNOTATION_NAMES, RED
 from insitupy._core._mixins import DeepCopyMixin
 from insitupy._exceptions import InvalidFileTypeError
 from insitupy._io.files import (check_overwrite_and_remove_if_true,
@@ -196,6 +196,9 @@ class ShapesData(DeepCopyMixin):
         else:
             if "name" not in new_df.columns:
                 new_df["name"] = ["None"] * len(new_df)
+                
+            if "color" not in new_df.columns:
+                new_df["color"] = [RED] * len(new_df)
 
             if self._forbidden_names is not None:
                 try:


### PR DESCRIPTION
Update import_annotations to ensure the presence of color column in annotations dataframe, defaulting to red