### PR TITLE
fix: make image metadata JSON-serializable before writing to Zarr store (backport to main)

### DIFF
--- a/insitupy/_core/data.py
+++ b/insitupy/_core/data.py
@@ -1239,6 +1239,7 @@ class InSituData:
             images_as_zarr: bool = True,
             zarr_zipped: bool = False,
             images_max_resolution: Optional[Number] = None, # in µm per pixel
+            debug: bool = False,
             verbose: bool = True
             ):
         '''
@@ -1246,6 +1247,8 @@ class InSituData:
 
         Args:
             path: Path to save the data to.
+            debug: If True, enable detailed debug logging for image metadata
+                serialization during save.
         '''
         # check if the path already exists
         path = Path(path)
@@ -1279,6 +1282,7 @@ class InSituData:
                 images_as_zarr=images_as_zarr,
                 zipped=zarr_zipped,
                 max_resolution=images_max_resolution,
+                debug=debug,
                 verbose=False
                 )
 

--- a/insitupy/dataclasses/dataclasses.py
+++ b/insitupy/dataclasses/dataclasses.py
@@ -2097,6 +2097,7 @@ class ImageData(DeepCopyMixin):
              return_savepaths: bool = False,
              overwrite: bool = False,
              max_resolution: Optional[Number] = None, # in µm per pixel
+             debug: bool = False,
              verbose: bool = False
              ):
         """
@@ -2112,6 +2113,7 @@ class ImageData(DeepCopyMixin):
             return_savepaths (bool): If True, return the paths of the saved files.
             overwrite (bool): If True, overwrite existing files in the output folder. Default is False.
             max_resolution (Optional[Number]): Maximum resolution for images in µm per pixel. If the pixel size of an image is larger than `max_resolution`, the image is downscaled. Default is None.
+            debug (bool): If True, emit detailed debug logs for metadata serialization failures during zarr writing.
             verbose (bool): If True, print status messages during saving. Default is True.
 
         Returns:
@@ -2224,12 +2226,27 @@ class ImageData(DeepCopyMixin):
                             )
                             continue
 
-                    write_zarr(image=img, file=img_path,
-                               img_metadata=new_img_metadata,
-                               save_pyramid=save_pyramid,
-                               axes=axes, verbose=verbose,
-                               overwrite=overwrite
-                               )
+                    try:
+                        write_zarr(image=img, file=img_path,
+                                   img_metadata=new_img_metadata,
+                                   save_pyramid=save_pyramid,
+                                   axes=axes, verbose=verbose,
+                                   overwrite=overwrite
+                                   )
+                    except TypeError as e:
+                        if debug and "is not JSON serializable" in str(e):
+                            logger.debug(
+                                "Failed to save image '%s' as zarr due to non-JSON-serializable metadata.",
+                                name,
+                            )
+                            for meta_key, meta_value in new_img_metadata.items():
+                                logger.debug(
+                                    "metadata key='%s', type='%s', value=%r",
+                                    meta_key,
+                                    type(meta_value).__name__,
+                                    meta_value,
+                                )
+                        raise
                 else:
                     # get file name for saving
                     #filename = Path(img_metadata["file"]).name.split(".")[0] + ".ome.tif"

--- a/insitupy/dataclasses/io.py
+++ b/insitupy/dataclasses/io.py
@@ -357,6 +357,7 @@ def _save_images(imagedata: ImageData,
                  images_as_zarr: bool = True,
                  zipped: bool = False,
                  max_resolution: Optional[Number] = None, # in µm per pixel,
+                 debug: bool = False,
                  verbose: bool = False
                  ):
     img_path = (path / "images")
@@ -367,6 +368,7 @@ def _save_images(imagedata: ImageData,
         zipped=zipped,
         return_savepaths=True,
         max_resolution=max_resolution,
+        debug=debug,
         verbose=verbose
         )
 

--- a/insitupy/images/io.py
+++ b/insitupy/images/io.py
@@ -16,7 +16,7 @@ from insitupy import __version__
 from insitupy._exceptions import InvalidFileTypeError
 from insitupy.images.axes import ImageAxes, normalize_axes_and_shape
 from insitupy.images.utils import _get_chunksize, create_img_pyramid
-from insitupy.utils.utils import convert_to_list
+from insitupy.utils.utils import convert_to_list, make_json_serializable
 
 logger = logging.getLogger(__name__)
 
@@ -436,7 +436,7 @@ def write_zarr(image, file,
 
         # open zarr store save metadata in zarr store
         store = zarr.open(dirstore, mode="a")
-        store.attrs.put(img_metadata)
+        store.attrs.put(make_json_serializable(img_metadata))
     # for k,v in img_metadata.items():
     #     store.attrs[k] = v
 

--- a/insitupy/utils/utils.py
+++ b/insitupy/utils/utils.py
@@ -69,6 +69,45 @@ def nested_dict_numpy_to_list(dictionary):
         elif isinstance(value, dict):
             nested_dict_numpy_to_list(value)
 
+def make_json_serializable(value):
+    """Recursively convert common non-JSON types to JSON-safe Python objects.
+
+    Handles nested mappings/sequences and converts NumPy scalar/array types
+    into native Python primitives so that ``json.dumps`` can serialize them.
+
+    Args:
+        value: Any Python object.
+
+    Returns:
+        A JSON-serializable representation of *value*.
+    """
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+
+    if isinstance(value, np.generic):
+        return value.item()
+
+    if isinstance(value, np.ndarray):
+        return [make_json_serializable(v) for v in value.tolist()]
+
+    if isinstance(value, dict):
+        return {str(k): make_json_serializable(v) for k, v in value.items()}
+
+    if isinstance(value, (list, tuple, set)):
+        return [make_json_serializable(v) for v in value]
+
+    if isinstance(value, os.PathLike):
+        return os.fspath(value)
+
+    if isinstance(value, pd.Timestamp):
+        return value.isoformat()
+
+    if isinstance(value, np.datetime64):
+        return str(value)
+
+    return str(value)
+
+
 def get_nrows_maxcols(n_keys, max_cols):
     '''
     Determine optimal number of rows and columns for `plt.subplot` based on

--- a/tests/test_json_serializable.py
+++ b/tests/test_json_serializable.py
@@ -1,0 +1,137 @@
+"""
+Regression tests for the JSON-serialization fix in images/io.write_zarr and
+the make_json_serializable helper in utils/utils.
+"""
+import json
+import shutil
+import tempfile
+from pathlib import Path
+
+import dask.array as da
+import numpy as np
+import zarr
+
+from insitupy.images.io import write_zarr
+from insitupy.utils.utils import make_json_serializable
+
+
+# ---------------------------------------------------------------------------
+# Tests for make_json_serializable
+# ---------------------------------------------------------------------------
+
+def test_make_json_serializable_numpy_scalar():
+    result = make_json_serializable(np.int64(42))
+    assert result == 42
+    assert isinstance(result, int)
+    # Verify json.dumps does not raise
+    json.dumps(result)
+
+
+def test_make_json_serializable_numpy_float():
+    result = make_json_serializable(np.float32(3.14))
+    assert isinstance(result, float)
+    json.dumps(result)
+
+
+def test_make_json_serializable_numpy_array():
+    arr = np.array([1, 2, 3], dtype=np.int64)
+    result = make_json_serializable(arr)
+    assert result == [1, 2, 3]
+    json.dumps(result)
+
+
+def test_make_json_serializable_nested_dict():
+    data = {"a": np.int64(1), "b": {"c": np.float32(2.5)}}
+    result = make_json_serializable(data)
+    json.dumps(result)
+    assert result["a"] == 1
+    assert abs(result["b"]["c"] - 2.5) < 1e-3
+
+
+def test_make_json_serializable_passthrough():
+    for v in [None, True, False, 1, 2.0, "hello", [1, 2], {"k": "v"}]:
+        result = make_json_serializable(v)
+        json.dumps(result)
+
+
+def test_make_json_serializable_path(tmp_path):
+    result = make_json_serializable(tmp_path)
+    assert isinstance(result, str)
+    json.dumps(result)
+
+
+# ---------------------------------------------------------------------------
+# Tests for write_zarr with numpy-typed metadata
+# ---------------------------------------------------------------------------
+
+def test_write_zarr_with_numpy_scalar_metadata():
+    """write_zarr must succeed and produce valid Zarr attrs when metadata
+    contains numpy scalar values (pre-fix this would raise TypeError)."""
+    img = da.from_array(np.zeros((3, 64, 64), dtype=np.uint8))
+    metadata = {
+        "pixel_size": np.float64(0.2125),
+        "axes": "CYX",
+        "channel_names": ["DAPI", "GFP", "RFP"],
+        "shape": np.array([3, 64, 64]),
+        "rgb": False,
+    }
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        outpath = Path(tmpdir) / "test.zarr"
+        write_zarr(
+            image=img,
+            file=outpath,
+            img_metadata=metadata,
+            save_pyramid=False,
+            axes="CYX",
+            verbose=False,
+            overwrite=False,
+        )
+
+        # Verify the zarr store was written
+        assert outpath.exists()
+
+        # Load and verify attrs are JSON-serializable
+        store = zarr.open(str(outpath), mode="r")
+        attrs = dict(store.attrs)
+        serialized = json.dumps(attrs)   # must not raise
+        assert len(serialized) > 0
+
+        # Values must have been converted to native Python types
+        assert isinstance(attrs["pixel_size"], float)
+
+
+def test_write_zarr_attrs_contain_only_json_serializable_values():
+    """All values in written Zarr attrs must be natively JSON-serializable."""
+    img = da.from_array(np.zeros((1, 32, 32), dtype=np.uint16))
+    metadata = {
+        "pixel_size": np.float32(0.5),
+        "axes": "CYX",
+        "channel_names": np.array(["DAPI"]),
+        "shape": np.array([1, 32, 32]),
+        "rgb": False,
+    }
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        outpath = Path(tmpdir) / "test2.zarr"
+        write_zarr(
+            image=img,
+            file=outpath,
+            img_metadata=metadata,
+            save_pyramid=False,
+            axes="CYX",
+            verbose=False,
+            overwrite=False,
+        )
+
+        store = zarr.open(str(outpath), mode="r")
+        attrs = dict(store.attrs)
+
+        # Every value must be serializable with the standard json library
+        for key, val in attrs.items():
+            try:
+                json.dumps(val)
+            except TypeError as exc:
+                raise AssertionError(
+                    f"Zarr attr '{key}' is not JSON-serializable: {exc}"
+                ) from exc


### PR DESCRIPTION
- Add make_json_serializable() in utils/utils.py — recursively converts numpy scalars/arrays, dicts, lists, sets, PathLike, and Timestamp values to native Python JSON-safe types
- Apply make_json_serializable(img_metadata) in images/io.write_zarr() before store.attrs.put() to prevent TypeError on numpy-typed metadata
- Add debug: bool = False parameter to InSituData.saveas(), dataclasses.io._save_images(), and ImageData.save(); when True, emit detailed logger.debug messages identifying the offending metadata key/type on serialization failure
- Add regression tests in tests/test_json_serializable.py

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>