### PR TITLE
feat(interactive): GeometriesWidget Option D restructure + point size preservation

### DIFF
--- a/insitupy/_core/_napari.py
+++ b/insitupy/_core/_napari.py
@@ -378,7 +378,29 @@ if WITH_NAPARI:
                         updated['name'] = ""
                     updated.loc[updated.index[-1], 'name'] = intended_name
                     updated.loc[updated.index[-1], 'geometry_type'] = geometry_type_label
+
+                    # Compute next region name from `updated` *before* assigning
+                    # layer.features, which fires callbacks that may read layer.features.
+                    next_region_name = None
+                    if (layer.name.startswith(REGIONS_SYMBOL + " ")
+                            and hasattr(viewer_config, 'data')):
+                        import re as _re
+                        _existing = {n for n in updated.get('name', []) if isinstance(n, str)}
+                        _max_n = 0
+                        for _n in _existing:
+                            _m = _re.match(r'^Region (\d+)$', _n)
+                            if _m:
+                                _max_n = max(_max_n, int(_m.group(1)))
+                        next_region_name = f"Region {_max_n + 1}"
+
                     layer.features = updated
+
+                    # Advance current_properties so the next drawn shape gets the
+                    # pre-computed incremented name.
+                    if next_region_name is not None:
+                        cp = dict(layer.current_properties)
+                        cp['name'] = np.array([next_region_name], dtype='object')
+                        layer.current_properties = cp
 
                 elif event.action == "removing":
                     _uids_snapshot[id(layer)] = set(layer.features['uid'])

--- a/insitupy/_core/_napari.py
+++ b/insitupy/_core/_napari.py
@@ -378,6 +378,10 @@ if WITH_NAPARI:
                         updated['name'] = ""
                     updated.loc[updated.index[-1], 'name'] = intended_name
                     updated.loc[updated.index[-1], 'geometry_type'] = geometry_type_label
+                    if isinstance(layer, Points):
+                        if 'size' not in updated.columns:
+                            updated['size'] = np.nan
+                        updated.loc[updated.index[-1], 'size'] = float(layer.size[-1])
 
                     # Compute next region name from `updated` *before* assigning
                     # layer.features, which fires callbacks that may read layer.features.
@@ -418,6 +422,14 @@ if WITH_NAPARI:
         def _on_colors_changed(e, v=viewer):
             _update_colorlegend(v, viewer_config)
 
+        def _on_size_changed(event=None, _layer=None):
+            """Sync layer.size → features['size'] so the Features Table stays current."""
+            if _layer is None or 'size' not in _layer.features.columns:
+                return
+            updated = _layer.features.copy()
+            updated['size'] = np.array(_layer.size, dtype=float)
+            _layer.features = updated
+
         def _connect_layer_events(layer):
             layer.events.data.connect(_update_uid)
             layer.events.features.connect(
@@ -427,6 +439,9 @@ if WITH_NAPARI:
                 layer.events.edge_color.connect(_on_colors_changed)
             elif isinstance(layer, Points):
                 layer.events.face_color.connect(_on_colors_changed)
+                layer.events.size.connect(
+                    lambda e, _l=layer: _on_size_changed(e, _layer=_l)
+                )
 
         # Assign the function to data of all existing layers
         for layer in viewer.layers:

--- a/insitupy/_core/_napari.py
+++ b/insitupy/_core/_napari.py
@@ -426,7 +426,7 @@ if WITH_NAPARI:
             if isinstance(layer, Shapes):
                 layer.events.edge_color.connect(_on_colors_changed)
             elif isinstance(layer, Points):
-                layer.events.border_color.connect(_on_colors_changed)
+                layer.events.face_color.connect(_on_colors_changed)
 
         # Assign the function to data of all existing layers
         for layer in viewer.layers:

--- a/insitupy/containers/shapes_data.py
+++ b/insitupy/containers/shapes_data.py
@@ -128,7 +128,7 @@ class ShapesData(DeepCopyMixin):
         for key, df in self._data.items():
             meta[key] = {
                 f"n_{self._shape_name}": len(df),
-                "classes": sorted(df[self._name_col].unique().tolist()) if self._name_col in df.columns else ["unnamed"],
+                "names": sorted(df[self._name_col].unique().tolist()) if self._name_col in df.columns else ["unnamed"],
             }
         return meta
 

--- a/insitupy/containers/shapes_data.py
+++ b/insitupy/containers/shapes_data.py
@@ -10,13 +10,14 @@ from typing import List, Literal, Optional, Union
 import geopandas as gpd
 import numpy as np
 import pandas as pd
+from shapely import MultiPoint, Point, Polygon, affinity
+
 from insitupy._constants import FORBIDDEN_ANNOTATION_NAMES, RED, WITH_NAPARI
 from insitupy._io.files import check_overwrite_and_remove_if_true
 from insitupy._io.geo import parse_geopandas, write_qupath_geojson
 from insitupy._mixins import DeepCopyMixin
 from insitupy._textformat import textformat as tf
 from insitupy.utils.utils import convert_to_list
-from shapely import MultiPoint, Point, Polygon, affinity
 
 logger = logging.getLogger(__name__)
 
@@ -95,7 +96,7 @@ class ShapesData(DeepCopyMixin):
             for l, m in self.metadata.items():
                 # get metadata
                 n = m[f"n_{self._shape_name}"]
-                classes = m["classes"]
+                classes = m["names"]
                 classes_str = [f"'{elem}'" for elem in classes]
                 lc = len(classes)
 
@@ -103,7 +104,7 @@ class ShapesData(DeepCopyMixin):
                 r = (
                     f'{tf.Bold}{l}:{tf.ResetAll}\t{n} '
                     f'{self._shape_name}, {lc} '
-                    f'{"classes" if lc>1 else "class"} '
+                    f'{"names" if lc>1 else "name"} '
                 )
                 if lc < 10:
                     r += f'({", ".join(classes_str)})'
@@ -595,4 +596,5 @@ class RegionsData(ShapesData):
             RegionsData: The loaded RegionsData object.
         """
         from insitupy.containers.io import _read_shapesdata
+        return _read_shapesdata(path, mode="regions", scale_factor=scale_factor)
         return _read_shapesdata(path, mode="regions", scale_factor=scale_factor)

--- a/insitupy/interactive/_callbacks.py
+++ b/insitupy/interactive/_callbacks.py
@@ -135,54 +135,57 @@ if WITH_NAPARI:
         layer = _resolve_legend_layer(viewer, layer)
 
         if isinstance(layer, napari.layers.points.points.Points):
-            try:
-                # get values
-                values = layer.properties["value"]
-                color_values = layer.face_color
-            except KeyError:
-                first_char = layer.name[:1]
-                if first_char == POINTS_SYMBOL:
-                    # collect the layer names and edge colors of the respective layer
-                    layer_names = []
-                    face_colors = []
-                    for elem in viewer.layers:
-                        if elem.name.startswith(first_char):
-                            layer_names.append(elem.name.strip(first_char + " "))
-                            face_colors.append(elem.current_face_color)
-
-                    # create mapping from collected values
-                    mapping = dict(zip(layer_names, face_colors))
-
-                    _update_categorical_legend(
-                        static_canvas=viewer_config.static_canvas,
-                        mapping=mapping,
-                        label="Points",
-                        marker="o",
-                        marker_mode="face"
+            first_char = layer.name[:1]
+            if first_char == POINTS_SYMBOL:
+                # Point annotation layer: build legend from features['name'] + face_color
+                # per point, analogous to the Shapes annotation branch below.
+                mapping = {}
+                for elem in viewer.layers:
+                    if not (elem.name.startswith(POINTS_SYMBOL)
+                            and isinstance(elem, napari.layers.Points)):
+                        continue
+                    if 'name' in elem.features.columns:
+                        for name, color in zip(elem.features['name'], elem.face_color):
+                            if name and name != "":
+                                mapping.setdefault(str(name), tuple(color))
+                    else:
+                        mapping.setdefault(
+                            elem.name[len(POINTS_SYMBOL) + 1:],
+                            tuple(elem.current_face_color)
                         )
+                mapping = {k: mapping[k] for k in sorted(mapping.keys())}
+                _update_categorical_legend(
+                    static_canvas=viewer_config.static_canvas,
+                    mapping=mapping,
+                    label="Point annotations",
+                    marker="o",
+                    marker_mode="face"
+                    )
             else:
-                if is_numeric_dtype(values):
-                    rgba_list, mapping = continuous_data_to_rgba(data=values,
-                                            cmap=layer.face_colormap.name,
-                                            #upper_climit_pct=upper_climit_pct,
-                                            return_mapping=True
-                                            )
-
-                    _update_continuous_legend(
-                        static_canvas=viewer_config.static_canvas,
-                        mapping=mapping,
-                        label=layer.name)
-
+                # Non-annotation Points layer (e.g. cell layer with continuous values).
+                try:
+                    values = layer.properties["value"]
+                    color_values = layer.face_color
+                except KeyError:
+                    pass
                 else:
-                    # substitute pd.NA with np.nan
-                    values = pd.Series(values).fillna(np.nan).values
-                    mapping = _categorical_mapping_without_missing(values, color_values)
-
-                    _update_categorical_legend(
-                        static_canvas=viewer_config.static_canvas,
-                        mapping=mapping,
-                        label=layer.name
-                        )
+                    if is_numeric_dtype(values):
+                        rgba_list, mapping = continuous_data_to_rgba(data=values,
+                                                cmap=layer.face_colormap.name,
+                                                return_mapping=True
+                                                )
+                        _update_continuous_legend(
+                            static_canvas=viewer_config.static_canvas,
+                            mapping=mapping,
+                            label=layer.name)
+                    else:
+                        values = pd.Series(values).fillna(np.nan).values
+                        mapping = _categorical_mapping_without_missing(values, color_values)
+                        _update_categorical_legend(
+                            static_canvas=viewer_config.static_canvas,
+                            mapping=mapping,
+                            label=layer.name
+                            )
 
         elif isinstance(layer, napari.layers.labels.labels.Labels):
             try:

--- a/insitupy/interactive/_layers.py
+++ b/insitupy/interactive/_layers.py
@@ -47,7 +47,8 @@ if WITH_NAPARI:
         if layer is None:
             return
         is_points = isinstance(layer, napari.layers.Points)
-        event = (layer.events.current_border_color if is_points
+        # Points encode name-color in face_color (analogous to edge_color for Shapes).
+        event = (layer.events.current_face_color if is_points
                  else layer.events.current_edge_color)
 
         def _on_color_change(event=None):
@@ -58,7 +59,7 @@ if WITH_NAPARI:
             selected = list(layer.selected_data)
             if not selected:
                 return
-            new_color = (layer.current_border_color if is_points
+            new_color = (layer.current_face_color if is_points
                          else layer.current_edge_color)
             if 'name' not in layer.features.columns:
                 return
@@ -69,8 +70,8 @@ if WITH_NAPARI:
                 mask = layer.features['name'] == name
                 indices = list(layer.features.index[mask])
                 if is_points:
-                    layer.border_color[indices] = new_color
-                    layer.events.border_color()
+                    layer.face_color[indices] = new_color
+                    layer.events.face_color()
                 else:
                     for i in indices:
                         layer._data_view.update_edge_color(i, new_color)
@@ -120,8 +121,8 @@ if WITH_NAPARI:
                   for nm in names]
         try:
             if is_points:
-                layer.border_color = [to_rgba(c) for c in colors]
-                layer.events.border_color()
+                layer.face_color = [to_rgba(c) for c in colors]
+                layer.events.face_color()
             else:
                 for i, hex_c in enumerate(colors):
                     layer._data_view.update_edge_color(i, to_rgba(hex_c))
@@ -405,6 +406,8 @@ if WITH_NAPARI:
                     size=10,
                     border_color="black",
                     face_color=color_list["Points"],
+                    text={'string': '{name}', 'anchor': 'upper_left',
+                          'size': 8, 'color': 'white'},
                     #scale=scale_factor
                 )
                 _connect_color_propagation(

--- a/insitupy/interactive/_layers.py
+++ b/insitupy/interactive/_layers.py
@@ -73,6 +73,10 @@ if WITH_NAPARI:
                     layer.face_color[indices] = new_color
                     layer.events.face_color()
                 else:
+                    # _data_view.update_edge_color is used intentionally here instead of
+                    # layer.edge_color = [...]: the public setter may fire
+                    # events.current_edge_color as a side effect, which would re-trigger
+                    # this very callback and cause an infinite loop.
                     for i in indices:
                         layer._data_view.update_edge_color(i, new_color)
                     layer.events.edge_color()
@@ -122,11 +126,9 @@ if WITH_NAPARI:
         try:
             if is_points:
                 layer.face_color = [to_rgba(c) for c in colors]
-                layer.events.face_color()
             else:
-                for i, hex_c in enumerate(colors):
-                    layer._data_view.update_edge_color(i, to_rgba(hex_c))
-                layer.events.edge_color()
+                # Use the public edge_color setter (fires events.edge_color automatically).
+                layer.edge_color = [to_rgba(c) for c in colors]
         except Exception:
             logger.exception("_apply_colors_from_features failed")
 
@@ -152,6 +154,7 @@ if WITH_NAPARI:
         uid_list = {"Points": [], "Shapes": []}
         type_list = {"Points": [], "Shapes": []} # list to store whether the polygon is exterior or interior
         names_list = {"Points": [], "Shapes": []}
+        size_list = {"Points": []}
 
         # hardcode edge_width based on type
         edge_width = 10 if mode == "Regions" else 4
@@ -301,6 +304,8 @@ if WITH_NAPARI:
                     # a normal Point object does not have multiple geometries and coordinates can be accessed directly
                     point_coords = [geometry.coords.xy]
 
+                row_size = float(row["size"]) if "size" in dataframe.columns else 10.0
+
                 # collect coordinates and other data on the points
                 for coord in point_coords:
                     point_x_list.append(coord[1].tolist()[0])
@@ -309,6 +314,7 @@ if WITH_NAPARI:
                     uid_list["Points"].append(uid)  # collect corresponding unique id
                     type_list["Points"].append("point") # information on type of coordinates - important for interior/exterior of polygons
                     names_list["Points"].append(row["name"])
+                    size_list["Points"].append(row_size)
 
         if len(shape_list) > 0:
             features_dict = {
@@ -375,6 +381,7 @@ if WITH_NAPARI:
                         'type': type_list["Points"],
                         'name': names_list["Points"],
                         'geometry_type': [geometry_type] * len(uid_list["Points"]),
+                        'size': size_list["Points"],
                     }
 
             if points_layer_name_with_symbol in viewer.layers:
@@ -385,8 +392,9 @@ if WITH_NAPARI:
                     coords=point_data,
                 )
 
-                # change colors of the newly added data
+                # change colors and sizes of the newly added data
                 layer.face_color[-len(point_data):] = color_list["Points"]
+                layer.size[-len(point_data):] = size_list["Points"]
                 layer.refresh() # refresh layer to show new colors
 
                 # layer.add() already appended empty rows to layer.features; fill them in
@@ -397,13 +405,14 @@ if WITH_NAPARI:
                 updated.loc[updated.index[-n:], 'type'] = features_dict['type']
                 updated.loc[updated.index[-n:], 'name'] = features_dict['name']
                 updated.loc[updated.index[-n:], 'geometry_type'] = features_dict['geometry_type']
+                updated.loc[updated.index[-n:], 'size'] = features_dict['size']
                 layer.features = updated
             else:
                 viewer.add_points(
                     data=point_data,
                     name=points_layer_name_with_symbol,
                     features=features_dict,
-                    size=10,
+                    size=size_list["Points"],
                     border_color="black",
                     face_color=color_list["Points"],
                     text={'string': '{name}', 'anchor': 'upper_left',

--- a/insitupy/interactive/_widgets.py
+++ b/insitupy/interactive/_widgets.py
@@ -1221,8 +1221,10 @@ if WITH_NAPARI:
                     name=layer_name,
                     size=10,
                     border_color='black',
-                    face_color='blue',
+                    face_color='#808080',
                     features=features,
+                    text={'string': '{name}', 'anchor': 'upper_left',
+                          'size': 8, 'color': 'white'},
                 )
             elif type_text == "Regions":
                 self.viewer.add_shapes(
@@ -1261,7 +1263,7 @@ if WITH_NAPARI:
                 )
             try:
                 if isinstance(layer, _nl.Points):
-                    layer.current_border_color = color
+                    layer.current_face_color = color
                 else:
                     layer.current_edge_color = color
             except Exception:

--- a/insitupy/interactive/_widgets.py
+++ b/insitupy/interactive/_widgets.py
@@ -19,8 +19,8 @@ if WITH_NAPARI:
     from qtpy.QtCore import QSize, Qt
     from qtpy.QtGui import QFontMetrics, QIcon
     from qtpy.QtWidgets import (QComboBox, QCompleter, QFileDialog,
-                                QHBoxLayout, QLabel, QLineEdit, QPushButton,
-                                QVBoxLayout, QWidget)
+                                QHBoxLayout, QInputDialog, QLabel, QLineEdit,
+                                QPushButton, QVBoxLayout, QWidget)
     from scipy.sparse import issparse
 
     from insitupy._constants import (ANNOTATIONS_SYMBOL,
@@ -881,6 +881,34 @@ if WITH_NAPARI:
             show_units_widget,
             )
 
+    _ALL = "(all)"
+
+    # NOTE: must remain inside the `if WITH_NAPARI:` block — napari types are
+    # referenced in the signature and body.
+    def _get_next_region_name_for_layer(viewer: napari.Viewer, key: str, viewer_config) -> str:
+        """Return the next auto-incremented region name for *key* across viewer + InSituData."""
+        import re
+        existing: set = set()
+        layer_name = f"{REGIONS_SYMBOL} {key}"
+        if layer_name in viewer.layers:
+            layer = viewer.layers[layer_name]
+            for n in layer.features.get('name', []):
+                if isinstance(n, str):
+                    existing.add(n)
+        data = viewer_config.data
+        if not data.regions.is_empty and key in data.regions.keys():
+            df = data.regions[key]
+            if 'name' in df.columns:
+                for n in df['name'].dropna():
+                    if isinstance(n, str):
+                        existing.add(n)
+        max_n = 0
+        for n in existing:
+            m = re.match(r'^Region (\d+)$', n)
+            if m:
+                max_n = max(max_n, int(m.group(1)))
+        return f"Region {max_n + 1}"
+
     class GeometriesWidget(QWidget):
         """Unified widget for showing and adding geometry layers (annotations/regions)."""
 
@@ -914,17 +942,24 @@ if WITH_NAPARI:
             name_row = QHBoxLayout()
             name_row.addWidget(QLabel("Name:"))
             self.name_combo = QComboBox()
-            self.name_combo.setEditable(True)
+            self.name_combo.setEditable(False)
             self.name_combo.setToolTip(
-                "Name assigned to the geometries. '<ALL>' loads all names for this key."
+                "Filter by name. '(all)' loads all shapes for this key."
             )
             name_row.addWidget(self.name_combo)
             layout.addLayout(name_row)
 
-            # Add button
-            self.add_btn = QPushButton("Add")
-            self.add_btn.clicked.connect(self._on_add)
-            layout.addWidget(self.add_btn)
+            # Show / Add new buttons
+            btn_row = QHBoxLayout()
+            self.show_btn = QPushButton("Show")
+            self.show_btn.setToolTip("Load shapes from InSituData into the viewer")
+            self.show_btn.clicked.connect(self._on_show)
+            btn_row.addWidget(self.show_btn)
+            self.add_new_btn = QPushButton("Add new")
+            self.add_new_btn.setToolTip("Create a new empty layer for drawing")
+            self.add_new_btn.clicked.connect(self._on_add_new)
+            btn_row.addWidget(self.add_new_btn)
+            layout.addLayout(btn_row)
 
             # Features Table button
             self.features_btn = QPushButton("Open Features Table")
@@ -932,7 +967,7 @@ if WITH_NAPARI:
             layout.addWidget(self.features_btn)
 
             # Connect signals
-            self.type_combo.currentIndexChanged.connect(self._refresh_key_combo)
+            self.type_combo.currentIndexChanged.connect(self._on_type_changed)
             self.key_combo.currentIndexChanged.connect(self._refresh_name_combo)
             self.key_combo.editTextChanged.connect(self._refresh_name_combo)
             viewer.layers.events.inserted.connect(self._refresh_key_combo)
@@ -953,6 +988,17 @@ if WITH_NAPARI:
                 return data.annotations
             return data.regions
 
+        def _on_type_changed(self, event=None):
+            """Reset Key and Name to defaults when the type selection changes."""
+            self.key_combo.blockSignals(True)
+            self.key_combo.setCurrentIndex(-1)
+            self.key_combo.clearEditText()
+            self.key_combo.blockSignals(False)
+            self.name_combo.blockSignals(True)
+            self.name_combo.setCurrentIndex(0)  # (all)
+            self.name_combo.blockSignals(False)
+            self._refresh_key_combo()
+
         def _refresh_key_combo(self, event=None):
             geom = self._get_geom_container()
             keys = (sorted(geom.keys(), key=str.casefold)
@@ -966,7 +1012,12 @@ if WITH_NAPARI:
                 self.key_combo.setCurrentIndex(idx)
             elif current:
                 self.key_combo.setEditText(current)
+            else:
+                self.key_combo.setCurrentIndex(-1)
+                self.key_combo.clearEditText()
             self.key_combo.blockSignals(False)
+            # Explicit call required: setEditText above fires no signal while
+            # blocked, so _refresh_name_combo would not run otherwise.
             self._refresh_name_combo()
 
         def _refresh_name_combo(self, event=None):
@@ -976,7 +1027,7 @@ if WITH_NAPARI:
             self.name_combo.blockSignals(True)
             current = self.name_combo.currentText()
             self.name_combo.clear()
-            self.name_combo.addItem("<ALL>")
+            self.name_combo.addItem(_ALL)
             if key_text and not geom.is_empty:
                 try:
                     meta = geom.metadata.get(key_text, {})
@@ -998,57 +1049,31 @@ if WITH_NAPARI:
             idx = self.name_combo.findText(current)
             if idx >= 0:
                 self.name_combo.setCurrentIndex(idx)
-            elif current:
-                self.name_combo.setEditText(current)
             else:
-                # Default to empty — don't inherit the <ALL> placeholder
-                self.name_combo.setCurrentIndex(-1)
-                self.name_combo.clearEditText()
+                self.name_combo.setCurrentIndex(0)  # default to (all)
             self.name_combo.blockSignals(False)
 
         def _get_next_region_name(self, key_text: str) -> str:
-            """Return the next auto-incremented region name ("Region 1", "Region 2", …)."""
-            import re
-            existing: set = set()
-            layer_name = f"{REGIONS_SYMBOL} {key_text}"
-            if layer_name in self.viewer.layers:
-                layer = self.viewer.layers[layer_name]
-                for n in layer.features.get('name', []):
-                    if isinstance(n, str):
-                        existing.add(n)
-            data = self.viewer_config.data
-            if not data.regions.is_empty and key_text in data.regions.keys():
-                df = data.regions[key_text]
-                if 'name' in df.columns:
-                    for n in df['name'].dropna():
-                        if isinstance(n, str):
-                            existing.add(n)
-            max_n = 0
-            for n in existing:
-                m = re.match(r'^Region (\d+)$', n)
-                if m:
-                    max_n = max(max_n, int(m.group(1)))
-            return f"Region {max_n + 1}"
+            return _get_next_region_name_for_layer(self.viewer, key_text, self.viewer_config)
 
-        def _on_add(self):
-            import warnings
+        def _on_show(self):
+            """Load existing shapes from InSituData into the viewer."""
             name_text = self.name_combo.currentText().strip()
             key_text = self.key_combo.currentText().strip()
             type_text = self.type_combo.currentText()
             data = self.viewer_config.data
-            config = self.viewer_config
 
             if not key_text:
                 show_warning("Please enter a key.")
                 return
 
-            load_all = (name_text == "<ALL>")
+            load_all = (name_text == _ALL)
 
             if type_text in ("Annotations", "Point annotations"):
                 geom_attr = "annotations"
                 symbol = (ANNOTATIONS_SYMBOL if type_text == "Annotations"
                           else POINTS_SYMBOL)
-                internal_mode = "Annotations"  # for the shapes function
+                internal_mode = type_text  # "Annotations" or "Point annotations"
             else:
                 geom_attr = "regions"
                 symbol = REGIONS_SYMBOL
@@ -1057,58 +1082,39 @@ if WITH_NAPARI:
             geom_container = getattr(data, geom_attr)
             layer_name = f"{symbol} {key_text}"
 
-            # Guard: key no longer in container
-            if not geom_container.is_empty and key_text not in geom_container.keys():
-                if not load_all:
-                    pass  # creating new key — allowed
-                # else still allowed for new key with <ALL>
-
             key_exists = (not geom_container.is_empty
                           and key_text in geom_container.keys())
 
-            if key_exists and not load_all:
-                meta = geom_container.metadata.get(key_text, {})
-                if 'names' in meta:
-                    names_list = meta['names']
-                elif 'classes' in meta:
-                    names_list = meta['classes']
-                else:
-                    names_list = []
-                name_exists = name_text in names_list
-            else:
-                name_exists = load_all and key_exists
-
-            if not (key_exists and name_exists):
-                # Annotations always start unnamed; regions get an auto-incremented name.
-                if type_text in ("Annotations", "Point annotations"):
-                    effective_name = ""
-                else:
-                    effective_name = self._get_next_region_name(key_text)
-                self._create_new_layer(type_text, key_text, effective_name,
-                                       layer_name, internal_mode, config)
+            if not key_exists:
+                show_warning(
+                    f"Key '{key_text}' not found in {geom_attr}. "
+                    "Use 'Add new' to create a new layer."
+                )
                 return
 
-            # Load existing data
+            # Load data, filtered by name if requested
             df = geom_container[key_text]
             if not load_all:
                 df = df[df['name'] == name_text]
+                if df.empty:
+                    show_info(f"No shapes with name '{name_text}' in key '{key_text}'.")
+                    return
 
             if type_text == "Regions":
                 if layer_name in self.viewer.layers:
+                    filter_hint = (f" (filter: '{name_text}')"
+                                   if not load_all else "")
                     show_warning(
-                        f"Layer '{layer_name}' already exists. Use sync to update."
+                        f"Layer '{layer_name}' already exists{filter_hint}. Use Sync to update."
                     )
                     return
             else:
-                # Annotations: merge new UIDs into existing layer if present
-                shapes_layer = f"{ANNOTATIONS_SYMBOL} {key_text}"
-                points_layer = f"{POINTS_SYMBOL} {key_text}"
-                for existing_ln in (shapes_layer, points_layer):
-                    if existing_ln in self.viewer.layers:
-                        if 'uid' not in df.columns:
-                            # Loaded data has no uid column (e.g. after sync/save);
-                            # cannot deduplicate, so load all rows.
-                            break
+                # Annotations: merge new UIDs into existing layer if present.
+                # Only check the layer that matches the current type to avoid
+                # deduplicating against UIDs from a different geometry type.
+                existing_ln = layer_name
+                if existing_ln in self.viewer.layers:
+                    if 'uid' in df.columns:
                         existing_uids = set(
                             self.viewer.layers[existing_ln].features['uid']
                         )
@@ -1118,7 +1124,6 @@ if WITH_NAPARI:
                                 "No new geometries to add — all are already in the viewer."
                             )
                             return
-                        break
 
             _add_geometries_as_layer(
                 dataframe=df,
@@ -1126,6 +1131,49 @@ if WITH_NAPARI:
                 layer_name=key_text,
                 mode=internal_mode,
             )
+
+            # napari derives current_properties from the last row of the
+            # features table whenever layer.features is assigned (see
+            # _get_default_column in layer_utils.py: value = column.iloc[-1]).
+            # For annotation layers this would carry the last loaded shape's
+            # name into subsequent draws. Reset it to "" so new shapes start
+            # unnamed.
+            if type_text in ("Annotations", "Point annotations"):
+                if layer_name in self.viewer.layers:
+                    layer = self.viewer.layers[layer_name]
+                    cp = dict(layer.current_properties)
+                    cp['name'] = np.array([''], dtype='object')
+                    layer.current_properties = cp
+
+
+        def _on_add_new(self):
+            """Create a new empty layer for drawing, prompting for a key name."""
+            type_text = self.type_combo.currentText()
+            config = self.viewer_config
+
+            if type_text in ("Annotations", "Point annotations"):
+                symbol = (ANNOTATIONS_SYMBOL if type_text == "Annotations"
+                          else POINTS_SYMBOL)
+                internal_mode = "Annotations"
+                effective_name = ""
+            else:
+                symbol = REGIONS_SYMBOL
+                internal_mode = "Regions"
+                effective_name = None  # determined after key is known
+
+            key_text, ok = QInputDialog.getText(
+                self, "Add new layer", "Key:"
+            )
+            key_text = key_text.strip()
+            if not ok or not key_text:
+                return
+
+            if effective_name is None:
+                effective_name = self._get_next_region_name(key_text)
+
+            layer_name = f"{symbol} {key_text}"
+            self._create_new_layer(type_text, key_text, effective_name,
+                                   layer_name, internal_mode, config)
 
         def _create_new_layer(self, type_text, key_text, name_text,
                               layer_name, internal_mode, config):
@@ -1145,11 +1193,14 @@ if WITH_NAPARI:
             }
 
             if layer_name in self.viewer.layers:
-                # Layer exists — update current_properties for new name
+                # Layer exists — update current_properties for new name and
+                # ensure color propagation is wired (may not be if layer was
+                # created in a prior session without this call).
                 layer = self.viewer.layers[layer_name]
                 layer.current_properties = current_props
                 if name_text:
                     self._set_layer_draw_color(layer, type_text, key_text, name_text, config)
+                _connect_color_propagation(layer, config, key_text, type_text)
                 return
 
             if type_text == "Annotations":
@@ -1217,27 +1268,36 @@ if WITH_NAPARI:
                 pass
 
         def _open_features_table(self):
-            key_text = self.key_combo.currentText().strip()
-            type_text = self.type_combo.currentText()
-            if type_text == "Annotations":
-                layer_name = f"{ANNOTATIONS_SYMBOL} {key_text}"
-            elif type_text == "Point annotations":
-                layer_name = f"{POINTS_SYMBOL} {key_text}"
+            # Prefer the currently active layer; fall back to key combo lookup.
+            active = self.viewer.layers.selection.active
+            if active is not None and isinstance(
+                active, (napari.layers.Shapes, napari.layers.Points)
+            ):
+                layer = active
             else:
-                layer_name = f"{REGIONS_SYMBOL} {key_text}"
+                key_text = self.key_combo.currentText().strip()
+                type_text = self.type_combo.currentText()
+                if type_text == "Annotations":
+                    layer_name = f"{ANNOTATIONS_SYMBOL} {key_text}"
+                elif type_text == "Point annotations":
+                    layer_name = f"{POINTS_SYMBOL} {key_text}"
+                else:
+                    layer_name = f"{REGIONS_SYMBOL} {key_text}"
 
-            if layer_name in self.viewer.layers:
+                if layer_name not in self.viewer.layers:
+                    show_warning("Layer not found in viewer. Add it first.")
+                    return
                 layer = self.viewer.layers[layer_name]
-                result = self.viewer.window.add_plugin_dock_widget(
-                    plugin_name="napari", widget_name="Features table widget"
-                )
-                if result is not None:
-                    dock = result[0] if isinstance(result, tuple) else result
-                    dock.setFloating(True)
 
-                self.viewer.layers.selection.active = layer
-            else:
-                show_warning("Layer not found in viewer. Add it first.")
+            result = self.viewer.window.add_plugin_dock_widget(
+                plugin_name="napari", widget_name="Features table widget"
+            )
+            if result is not None:
+                dock = result[0] if isinstance(result, tuple) else result
+                dock.setFloating(True)
+                dock.show()
+                dock.raise_()
+            self.viewer.layers.selection.active = layer
 
 
 

--- a/insitupy/interactive/_widgets.py
+++ b/insitupy/interactive/_widgets.py
@@ -922,11 +922,11 @@ if WITH_NAPARI:
             layout = QVBoxLayout()
             self.setLayout(layout)
 
-            # Type row
+            # Type row — Annotations vs Regions only; shapes/points is an Add-time choice
             type_row = QHBoxLayout()
             type_row.addWidget(QLabel("Type:"))
             self.type_combo = QComboBox()
-            self.type_combo.addItems(["Annotations", "Point annotations", "Regions"])
+            self.type_combo.addItems(["Annotations", "Regions"])
             type_row.addWidget(self.type_combo)
             layout.addLayout(type_row)
 
@@ -949,17 +949,23 @@ if WITH_NAPARI:
             name_row.addWidget(self.name_combo)
             layout.addLayout(name_row)
 
-            # Show / Add new buttons
-            btn_row = QHBoxLayout()
+            # Show button (geometry type handled internally)
             self.show_btn = QPushButton("Show")
-            self.show_btn.setToolTip("Load shapes from InSituData into the viewer")
+            self.show_btn.setToolTip("Load geometries from InSituData into the viewer")
             self.show_btn.clicked.connect(self._on_show)
-            btn_row.addWidget(self.show_btn)
-            self.add_new_btn = QPushButton("Add new")
-            self.add_new_btn.setToolTip("Create a new empty layer for drawing")
-            self.add_new_btn.clicked.connect(self._on_add_new)
-            btn_row.addWidget(self.add_new_btn)
-            layout.addLayout(btn_row)
+            layout.addWidget(self.show_btn)
+
+            # Add buttons — shapes always available; points only for Annotations
+            add_row = QHBoxLayout()
+            self.add_shapes_btn = QPushButton("Add shapes")
+            self.add_shapes_btn.setToolTip("Create a new empty shapes layer for drawing")
+            self.add_shapes_btn.clicked.connect(self._on_add_shapes)
+            add_row.addWidget(self.add_shapes_btn)
+            self.add_points_btn = QPushButton("Add points")
+            self.add_points_btn.setToolTip("Create a new empty points layer for drawing")
+            self.add_points_btn.clicked.connect(self._on_add_points)
+            add_row.addWidget(self.add_points_btn)
+            layout.addLayout(add_row)
 
             # Features Table button
             self.features_btn = QPushButton("Open Features Table")
@@ -982,14 +988,13 @@ if WITH_NAPARI:
             super().closeEvent(event)
 
         def _get_geom_container(self):
-            type_text = self.type_combo.currentText()
             data = self.viewer_config.data
-            if type_text in ("Annotations", "Point annotations"):
+            if self.type_combo.currentText() == "Annotations":
                 return data.annotations
             return data.regions
 
         def _on_type_changed(self, event=None):
-            """Reset Key and Name to defaults when the type selection changes."""
+            """Reset Key/Name and update Add points availability on type change."""
             self.key_combo.blockSignals(True)
             self.key_combo.setCurrentIndex(-1)
             self.key_combo.clearEditText()
@@ -997,6 +1002,8 @@ if WITH_NAPARI:
             self.name_combo.blockSignals(True)
             self.name_combo.setCurrentIndex(0)  # (all)
             self.name_combo.blockSignals(False)
+            is_annotations = self.type_combo.currentText() == "Annotations"
+            self.add_points_btn.setEnabled(is_annotations)
             self._refresh_key_combo()
 
         def _refresh_key_combo(self, event=None):
@@ -1057,7 +1064,12 @@ if WITH_NAPARI:
             return _get_next_region_name_for_layer(self.viewer, key_text, self.viewer_config)
 
         def _on_show(self):
-            """Load existing shapes from InSituData into the viewer."""
+            """Load existing geometries from InSituData into the viewer.
+
+            For Annotations the geometry type (shapes vs points) is determined
+            automatically from the stored data — both layers are created/updated
+            in one call. For Regions only a shapes layer is created.
+            """
             name_text = self.name_combo.currentText().strip()
             key_text = self.key_combo.currentText().strip()
             type_text = self.type_combo.currentText()
@@ -1068,31 +1080,19 @@ if WITH_NAPARI:
                 return
 
             load_all = (name_text == _ALL)
-
-            if type_text in ("Annotations", "Point annotations"):
-                geom_attr = "annotations"
-                symbol = (ANNOTATIONS_SYMBOL if type_text == "Annotations"
-                          else POINTS_SYMBOL)
-                internal_mode = type_text  # "Annotations" or "Point annotations"
-            else:
-                geom_attr = "regions"
-                symbol = REGIONS_SYMBOL
-                internal_mode = "Regions"
-
+            is_annotations = (type_text == "Annotations")
+            geom_attr = "annotations" if is_annotations else "regions"
             geom_container = getattr(data, geom_attr)
-            layer_name = f"{symbol} {key_text}"
 
             key_exists = (not geom_container.is_empty
                           and key_text in geom_container.keys())
-
             if not key_exists:
                 show_warning(
                     f"Key '{key_text}' not found in {geom_attr}. "
-                    "Use 'Add new' to create a new layer."
+                    "Use 'Add shapes' or 'Add points' to create a new layer."
                 )
                 return
 
-            # Load data, filtered by name if requested
             df = geom_container[key_text]
             if not load_all:
                 df = df[df['name'] == name_text]
@@ -1100,80 +1100,78 @@ if WITH_NAPARI:
                     show_info(f"No shapes with name '{name_text}' in key '{key_text}'.")
                     return
 
-            if type_text == "Regions":
+            if not is_annotations:
+                # Regions: single shapes layer — warn if already present
+                layer_name = f"{REGIONS_SYMBOL} {key_text}"
                 if layer_name in self.viewer.layers:
-                    filter_hint = (f" (filter: '{name_text}')"
-                                   if not load_all else "")
+                    filter_hint = f" (filter: '{name_text}')" if not load_all else ""
                     show_warning(
                         f"Layer '{layer_name}' already exists{filter_hint}. Use Sync to update."
                     )
                     return
+                _add_geometries_as_layer(
+                    dataframe=df,
+                    viewer=self.viewer,
+                    layer_name=key_text,
+                    mode="Regions",
+                )
             else:
-                # Annotations: merge new UIDs into existing layer if present.
-                # Only check the layer that matches the current type to avoid
-                # deduplicating against UIDs from a different geometry type.
-                existing_ln = layer_name
-                if existing_ln in self.viewer.layers:
-                    if 'uid' in df.columns:
-                        existing_uids = set(
-                            self.viewer.layers[existing_ln].features['uid']
-                        )
-                        df = df[~df['uid'].isin(existing_uids)]
-                        if df.empty:
-                            show_info(
-                                "No new geometries to add — all are already in the viewer."
-                            )
-                            return
-
-            _add_geometries_as_layer(
-                dataframe=df,
-                viewer=self.viewer,
-                layer_name=key_text,
-                mode=internal_mode,
-            )
-
-            # napari derives current_properties from the last row of the
-            # features table whenever layer.features is assigned (see
-            # _get_default_column in layer_utils.py: value = column.iloc[-1]).
-            # For annotation layers this would carry the last loaded shape's
-            # name into subsequent draws. Reset it to "" so new shapes start
-            # unnamed.
-            if type_text in ("Annotations", "Point annotations"):
-                if layer_name in self.viewer.layers:
-                    layer = self.viewer.layers[layer_name]
-                    cp = dict(layer.current_properties)
-                    cp['name'] = np.array([''], dtype='object')
-                    layer.current_properties = cp
+                # Annotations: _add_geometries_as_layer handles shapes and points
+                # internally; existing-layer dedup is done per-UID inside that function.
+                _add_geometries_as_layer(
+                    dataframe=df,
+                    viewer=self.viewer,
+                    layer_name=key_text,
+                    mode="Annotations",
+                )
+                # Reset current_properties name to "" on both possible annotation layers
+                # (napari promotes column.iloc[-1] to defaults on every features assignment).
+                for sym in (ANNOTATIONS_SYMBOL, POINTS_SYMBOL):
+                    ln = f"{sym} {key_text}"
+                    if ln in self.viewer.layers:
+                        layer = self.viewer.layers[ln]
+                        cp = dict(layer.current_properties)
+                        cp['name'] = np.array([''], dtype='object')
+                        layer.current_properties = cp
 
 
-        def _on_add_new(self):
-            """Create a new empty layer for drawing, prompting for a key name."""
-            type_text = self.type_combo.currentText()
+        def _on_add_shapes(self):
+            """Create a new empty shapes layer for drawing."""
+            type_text = self.type_combo.currentText()  # "Annotations" or "Regions"
             config = self.viewer_config
 
-            if type_text in ("Annotations", "Point annotations"):
-                symbol = (ANNOTATIONS_SYMBOL if type_text == "Annotations"
-                          else POINTS_SYMBOL)
-                internal_mode = "Annotations"
-                effective_name = ""
-            else:
-                symbol = REGIONS_SYMBOL
-                internal_mode = "Regions"
-                effective_name = None  # determined after key is known
-
-            key_text, ok = QInputDialog.getText(
-                self, "Add new layer", "Key:"
-            )
+            key_text, ok = QInputDialog.getText(self, "Add shapes layer", "Key:")
             key_text = key_text.strip()
             if not ok or not key_text:
                 return
 
-            if effective_name is None:
+            if type_text == "Regions":
+                symbol = REGIONS_SYMBOL
+                internal_mode = "Regions"
                 effective_name = self._get_next_region_name(key_text)
+            else:
+                symbol = ANNOTATIONS_SYMBOL
+                internal_mode = "Annotations"
+                effective_name = ""
 
             layer_name = f"{symbol} {key_text}"
             self._create_new_layer(type_text, key_text, effective_name,
                                    layer_name, internal_mode, config)
+
+        def _on_add_points(self):
+            """Create a new empty points layer for drawing (Annotations only)."""
+            config = self.viewer_config
+
+            key_text, ok = QInputDialog.getText(self, "Add points layer", "Key:")
+            key_text = key_text.strip()
+            if not ok or not key_text:
+                return
+
+            layer_name = f"{POINTS_SYMBOL} {key_text}"
+            # Use "Point annotations" as the internal type string so _create_new_layer
+            # calls viewer.add_points instead of viewer.add_shapes.
+            self._create_new_layer("Point annotations", key_text, "",
+                                   layer_name, "Annotations", config)
 
         def _create_new_layer(self, type_text, key_text, name_text,
                               layer_name, internal_mode, config):
@@ -1281,8 +1279,6 @@ if WITH_NAPARI:
                 type_text = self.type_combo.currentText()
                 if type_text == "Annotations":
                     layer_name = f"{ANNOTATIONS_SYMBOL} {key_text}"
-                elif type_text == "Point annotations":
-                    layer_name = f"{POINTS_SYMBOL} {key_text}"
                 else:
                     layer_name = f"{REGIONS_SYMBOL} {key_text}"
 
@@ -1407,7 +1403,13 @@ if WITH_NAPARI:
                 return
             viewer_config = config_manager[_get_viewer_uid(viewer)]
             for layer in viewer.layers:
-                if (isinstance(layer, (napari.layers.Shapes, napari.layers.Points))
+                if isinstance(layer, napari.layers.Points) and 'name' in layer.features.columns:
+                    # layer.size is authoritative — overwrite any Features Table edits
+                    # and fire features_update (which triggers refresh_text + colors)
+                    updated = layer.features.copy()
+                    updated['size'] = np.array(layer.size, dtype=float)
+                    layer.features = updated
+                elif (isinstance(layer, napari.layers.Shapes)
                         and 'name' in layer.features.columns):
                     layer.refresh_text()
                     _apply_colors_from_features(layer, viewer_config)

--- a/insitupy/interactive/viewer.py
+++ b/insitupy/interactive/viewer.py
@@ -291,6 +291,7 @@ if WITH_NAPARI:
                 "geometry": [Point(d[1], d[0]) for d in layer_data],  # switch x/y
                 "name": name_values,
                 "color": [[int(elem[e]*255) for e in range(3)] for elem in colors],
+                "size": layer.size.tolist(),
             }
 
         # generate GeoDataFrame


### PR DESCRIPTION
- GeometriesWidget: type_combo reduced to Annotations/Regions; Show is geometry-agnostic; Add new replaced by Add shapes + Add points buttons (Add points disabled for Regions); Key defaults to empty; Key/Name reset on type change only
- Point annotations: preserve per-point size (µm) across sync and reload; size stored in features['size'] and GeoDataFrame; layer.size is authoritative; auto-synced to Features Table via events.size connection
- Fix: Features Table reopens correctly with dock.show() + raise_()
- Fix: new shapes after re-show no longer inherit last assigned name
- Fix: metadata key renamed 'classes' → 'names' in ShapesData
- Refactor: _apply_colors_from_features uses public edge_color setter instead of private _data_view.update_edge_color

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>